### PR TITLE
jgi-mt data examples 

### DIFF
--- a/src/data/invalid/SampleData-jgi_mt_data-captilized-analysis_type.yaml
+++ b/src/data/invalid/SampleData-jgi_mt_data-captilized-analysis_type.yaml
@@ -1,0 +1,21 @@
+jgi_mt_data:
+  - samp_name: sample name
+    source_mat_id: MPI:012345
+    dnase_rna: "no"
+    proposal_rna: '504000'
+    rna_concentration: 100.3
+    rna_cont_type: plate 
+    rna_cont_well: H7
+    rna_container_id: cat_ht_1999
+    rna_isolate_meth: phenol/cloroform extraction
+    rna_project_contact: Leslie Ann Levine
+    rna_samp_id: '123456'
+    rna_sample_format: MDA reaction buffer
+    rna_sample_name: JGI_lagoon_14343
+    rna_seq_project: '123456789'
+    rna_seq_project_name: JGI Lagoon metatranscritpomics
+    rna_seq_project_pi: Patty Smith
+    rna_volume: 25.1
+    analysis_type: 
+      - Metatranscriptomics
+    

--- a/src/data/invalid/SampleData-jgi_mt_data-illegal-string-anlaysis_type.yaml
+++ b/src/data/invalid/SampleData-jgi_mt_data-illegal-string-anlaysis_type.yaml
@@ -1,0 +1,20 @@
+jgi_mt_data:
+  - samp_name: sample name
+    source_mat_id: MPI:012345
+    dnase_rna: "no"
+    proposal_rna: '504000'
+    rna_concentration: 100.3
+    rna_cont_type: plate 
+    rna_cont_well: H7
+    rna_container_id: cat_ht_1999
+    rna_isolate_meth: phenol/cloroform extraction
+    rna_project_contact: Leslie Ann Levine
+    rna_samp_id: '123456'
+    rna_sample_format: MDA reaction buffer
+    rna_sample_name: JGI_lagoon_14343
+    rna_seq_project: '123456789'
+    rna_seq_project_name: JGI Lagoon metatranscritpomics
+    rna_seq_project_pi: Patty Smith
+    rna_volume: 25.1
+    analysis_type: 
+      - transcriptomics

--- a/src/data/invalid/SampleData-jgi_mt_data-illegal-string-rna_absorb2.yaml
+++ b/src/data/invalid/SampleData-jgi_mt_data-illegal-string-rna_absorb2.yaml
@@ -1,0 +1,22 @@
+jgi_mt_data:
+  - samp_name: sample name
+    source_mat_id: MPI:012345
+    dnase_rna: "no"
+    proposal_rna: '504000'
+    rna_concentration: 100.3
+    rna_cont_type: plate 
+    rna_cont_well: H7
+    rna_container_id: cat_ht_1999
+    rna_isolate_meth: phenol/cloroform extraction
+    rna_project_contact: Leslie Ann Levine
+    rna_samp_id: '123456'
+    rna_sample_format: MDA reaction buffer
+    rna_sample_name: JGI_lagoon_14343
+    rna_seq_project: '123456789'
+    rna_seq_project_name: JGI Lagoon metatranscritpomics
+    rna_seq_project_pi: Patty Smith
+    rna_volume: 25.1
+    analysis_type: 
+      - metatranscriptomics
+    rna_absorb1: 2.02
+    rna_absorb2: two and a half

--- a/src/data/invalid/SampleData-jgi_mt_data-illegal-string-rna_volume.yaml
+++ b/src/data/invalid/SampleData-jgi_mt_data-illegal-string-rna_volume.yaml
@@ -1,0 +1,20 @@
+jgi_mt_data:
+  - samp_name: sample name
+    source_mat_id: MPI:012345
+    dnase_rna: "no"
+    proposal_rna: '504000'
+    rna_concentration: 100.3
+    rna_cont_type: plate 
+    rna_cont_well: H7
+    rna_container_id: cat_ht_1999
+    rna_isolate_meth: phenol/cloroform extraction
+    rna_project_contact: Leslie Ann Levine
+    rna_samp_id: '123456'
+    rna_sample_format: MDA reaction buffer
+    rna_sample_name: JGI_lagoon_14343
+    rna_seq_project: '123456789'
+    rna_seq_project_name: JGI Lagoon metatranscritpomics
+    rna_seq_project_pi: Patty Smith
+    rna_volume: Four hundred uL
+    analysis_type: 
+      - metatranscriptomics

--- a/src/data/invalid/SampleData-jgi_mt_data-illlegal-string-rna_absorb1.yaml
+++ b/src/data/invalid/SampleData-jgi_mt_data-illlegal-string-rna_absorb1.yaml
@@ -1,0 +1,21 @@
+jgi_mt_data:
+  - samp_name: sample name
+    source_mat_id: MPI:012345
+    dnase_rna: "no"
+    proposal_rna: '504000'
+    rna_concentration: 100.3
+    rna_cont_type: plate 
+    rna_cont_well: H7
+    rna_container_id: cat_ht_1999
+    rna_isolate_meth: phenol/cloroform extraction
+    rna_project_contact: Leslie Ann Levine
+    rna_samp_id: '123456'
+    rna_sample_format: MDA reaction buffer
+    rna_sample_name: JGI_lagoon_14343
+    rna_seq_project: '123456789'
+    rna_seq_project_name: JGI Lagoon metatranscritpomics
+    rna_seq_project_pi: Patty Smith
+    rna_volume: 25.1
+    analysis_type: 
+      - metatranscriptomics
+    rna_absorb1: one

--- a/src/data/unexpected_pass/SampleData-jgi_mt_data-illegal-rna_seq_project.yaml
+++ b/src/data/unexpected_pass/SampleData-jgi_mt_data-illegal-rna_seq_project.yaml
@@ -1,0 +1,20 @@
+jgi_mt_data:
+  - samp_name: sample name
+    source_mat_id: MPI:012345
+    dnase_rna: "no"
+    proposal_rna: '504000'
+    rna_concentration: 100.3
+    rna_cont_type: plate 
+    rna_cont_well: H7
+    rna_container_id: cat_ht_1999
+    rna_isolate_meth: phenol/cloroform extraction
+    rna_project_contact: Leslie Ann Levine
+    rna_samp_id: '123456'
+    rna_sample_format: MDA reaction buffer
+    rna_sample_name: JGI_lagoon_14343
+    rna_seq_project: An RNA Sequencing Project # Values will be prefilled by NMDC. Appears to accept any string.
+    rna_seq_project_name: JGI Lagoon metatranscritpomics
+    rna_seq_project_pi: Patty Smith
+    rna_volume: 25.1
+    analysis_type: 
+      - metatranscriptomics

--- a/src/data/unexpected_pass/SampleData-jgi_mt_data-illegal-rna_seq_project_name.yaml
+++ b/src/data/unexpected_pass/SampleData-jgi_mt_data-illegal-rna_seq_project_name.yaml
@@ -1,0 +1,20 @@
+jgi_mt_data:
+  - samp_name: sample name
+    source_mat_id: MPI:012345
+    dnase_rna: "no"
+    proposal_rna: '504000'
+    rna_concentration: 100.3
+    rna_cont_type: plate 
+    rna_cont_well: H7
+    rna_container_id: cat_ht_1999
+    rna_isolate_meth: phenol/cloroform extraction
+    rna_project_contact: Leslie Ann Levine
+    rna_samp_id: '123456'
+    rna_sample_format: MDA reaction buffer
+    rna_sample_name: JGI_lagoon_14343
+    rna_seq_project: '123456789'
+    rna_seq_project_name: RNA Sequencing Project Name # Values will be prefilled by NMDC. Appears to accept any string.
+    rna_seq_project_pi: Patty Smith
+    rna_volume: 25.1
+    analysis_type: 
+      - metatranscriptomics

--- a/src/data/unexpected_pass/SampleData-jgi_mt_data-illegal-rna_seq_project_pi.yaml
+++ b/src/data/unexpected_pass/SampleData-jgi_mt_data-illegal-rna_seq_project_pi.yaml
@@ -1,0 +1,20 @@
+jgi_mt_data:
+  - samp_name: sample name
+    source_mat_id: MPI:012345
+    dnase_rna: "no"
+    proposal_rna: '504000'
+    rna_concentration: 100.3
+    rna_cont_type: plate 
+    rna_cont_well: H7
+    rna_container_id: cat_ht_1999
+    rna_isolate_meth: phenol/cloroform extraction
+    rna_project_contact: Leslie Ann Levine
+    rna_samp_id: '123456'
+    rna_sample_format: MDA reaction buffer
+    rna_sample_name: JGI_lagoon_14343
+    rna_seq_project: '123456789'
+    rna_seq_project_name: JGI Lagoon metatranscritpomics
+    rna_seq_project_pi: Mary Poppins # Values will be prefilled by NMDC. Appears to accept any string.
+    rna_volume: 25.1
+    analysis_type: 
+      - metatranscriptomics

--- a/src/data/unexpected_pass/SampleData-jgi_mt_data-too-small-value-rna_volume.yaml
+++ b/src/data/unexpected_pass/SampleData-jgi_mt_data-too-small-value-rna_volume.yaml
@@ -1,0 +1,20 @@
+jgi_mt_data:
+  - samp_name: sample name
+    source_mat_id: MPI:012345
+    dnase_rna: "no"
+    proposal_rna: '504000'
+    rna_concentration: 100.3
+    rna_cont_type: plate 
+    rna_cont_well: H7
+    rna_container_id: cat_ht_1999
+    rna_isolate_meth: phenol/cloroform extraction
+    rna_project_contact: Leslie Ann Levine
+    rna_samp_id: '123456'
+    rna_sample_format: MDA reaction buffer
+    rna_sample_name: JGI_lagoon_14343
+    rna_seq_project: '123456789'
+    rna_seq_project_name: JGI Lagoon metatranscritpomics
+    rna_seq_project_pi: Patty Smith
+    rna_volume: 24 # According to documention: Values <25 only permitted by special permission.
+    analysis_type: 
+      - metatranscriptomics

--- a/src/data/unexpected_pass/SampleData.-jgi_mt_data-too-large-value-rna_volume.yaml
+++ b/src/data/unexpected_pass/SampleData.-jgi_mt_data-too-large-value-rna_volume.yaml
@@ -1,0 +1,20 @@
+jgi_mt_data:
+  - samp_name: sample name
+    source_mat_id: MPI:012345
+    dnase_rna: "no"
+    proposal_rna: '504000'
+    rna_concentration: 100.3
+    rna_cont_type: plate 
+    rna_cont_well: H7
+    rna_container_id: cat_ht_1999
+    rna_isolate_meth: phenol/cloroform extraction
+    rna_project_contact: Leslie Ann Levine
+    rna_samp_id: '123456'
+    rna_sample_format: MDA reaction buffer
+    rna_sample_name: JGI_lagoon_14343
+    rna_seq_project: '123456789'
+    rna_seq_project_name: JGI Lagoon metatranscritpomics
+    rna_seq_project_pi: Patty Smith
+    rna_volume: 2000 # According to documentation. Values must 0-1000
+    analysis_type: 
+      - metatranscriptomics

--- a/src/data/valid/SampleData-jgi_mt_data_exhaustive.yaml
+++ b/src/data/valid/SampleData-jgi_mt_data_exhaustive.yaml
@@ -1,0 +1,22 @@
+jgi_mt_data:
+  - samp_name: sample name
+    source_mat_id: MPI:012345
+    dnase_rna: "no"
+    proposal_rna: '504000'
+    rna_concentration: 100.3
+    rna_cont_type: plate 
+    rna_cont_well: H7
+    rna_container_id: cat_ht_1999
+    rna_isolate_meth: phenol/cloroform extraction
+    rna_project_contact: Leslie Ann Levine
+    rna_samp_id: '123456'
+    rna_sample_format: MDA reaction buffer
+    rna_sample_name: JGI_lagoon_14343
+    rna_seq_project: '123456789'
+    rna_seq_project_name: JGI Lagoon metatranscritpomics
+    rna_seq_project_pi: Patty Smith
+    rna_volume: 25.1
+    analysis_type: 
+      - metatranscriptomics
+    rna_absorb1: 2.02
+    rna_absorb2: 1.4


### PR DESCRIPTION
@turbomam @mslarae13 I added the last example files for the jgi-mt class (issue #102). I added minimum and exhaustive files in the valid folder. There are also a handful of unexpected_pass examples. Most of them are for slots that should have prefilled values by NMDC. I was not sure if these should be included as unexpected_pass or not, but I included them just in case. The other two files are for the `rna_volume` slot - it does not invalidate if a too small of too large value is entered. 

There are some other things I noted (I assume a lot has to do with the docs needing to be updated):

1. source_mat_code has an example in the docs that will not actually validate: https://microbiomedata.github.io/submission-schema/source_mat_id/ `MPI012345` will not validate because it is missing a colon. Update docs?
1. Many of the slots are listed as recommended that are in fact required.
1. Most slots (if not all) including `rna_absorb1` and `rna_absorb2` are included twice in the `JGIMtInterface` class list of slots in the documentation: https://microbiomedata.github.io/submission-schema/JgiMtInterface/