### PR TITLE
add jgi-mg-interaface sample data files

### DIFF
--- a/src/data/invalid/SampleData-jgi_mg_data-capital-dna_dnase.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_data-capital-dna_dnase.yaml
@@ -1,0 +1,20 @@
+jgi_mg_data:
+  - analysis_type:
+      - metagenomics
+      - metatranscriptomics
+    dna_concentration: 1.23
+    dna_cont_type: plate
+    dna_cont_well: C3
+    dna_container_id: xxx
+    dna_dnase: "No"
+    dna_isolate_meth: xxx
+    dna_project_contact: xxx
+    dna_samp_id: xxx
+    dna_sample_format: DNAStable
+    dna_sample_name: xxx
+    dna_seq_project: xxx
+    dna_seq_project_name: xxx
+    dna_seq_project_pi: xxx
+    dna_volume: 0
+    proposal_dna: xxx
+    samp_name: xxx

--- a/src/data/invalid/SampleData-jgi_mg_data-high-dna_concentration.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_data-high-dna_concentration.yaml
@@ -1,0 +1,20 @@
+jgi_mg_data:
+  - analysis_type:
+      - metagenomics
+      - metatranscriptomics
+    dna_concentration: 2001
+    dna_cont_type: plate
+    dna_cont_well: C3
+    dna_container_id: xxx
+    dna_dnase: "no"
+    dna_isolate_meth: xxx
+    dna_project_contact: xxx
+    dna_samp_id: xxx
+    dna_sample_format: DNAStable
+    dna_sample_name: xxx
+    dna_seq_project: xxx
+    dna_seq_project_name: xxx
+    dna_seq_project_pi: xxx
+    dna_volume: 0
+    proposal_dna: xxx
+    samp_name: xxx

--- a/src/data/invalid/SampleData-jgi_mg_data-illegal-string-dna_absorb1.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_data-illegal-string-dna_absorb1.yaml
@@ -1,0 +1,21 @@
+jgi_mg_data:
+  - analysis_type:
+      - metagenomics
+      - metatranscriptomics
+    dna_concentration: 1.23
+    dna_cont_type: plate
+    dna_cont_well: C3
+    dna_container_id: xxx
+    dna_dnase: "no"
+    dna_isolate_meth: xxx
+    dna_project_contact: xxx
+    dna_samp_id: xxx
+    dna_sample_format: DNAStable
+    dna_sample_name: xxx
+    dna_seq_project: xxx
+    dna_seq_project_name: xxx
+    dna_seq_project_pi: xxx
+    dna_volume: 0
+    proposal_dna: xxx
+    samp_name: xxx
+    dna_absorb1: seven

--- a/src/data/invalid/SampleData-jgi_mg_data-illegal-string-dna_concentration.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_data-illegal-string-dna_concentration.yaml
@@ -1,0 +1,20 @@
+jgi_mg_data:
+  - analysis_type:
+      - metagenomics
+      - metatranscriptomics
+    dna_concentration: five hundred
+    dna_cont_type: plate
+    dna_cont_well: C3
+    dna_container_id: xxx
+    dna_dnase: "no"
+    dna_isolate_meth: xxx
+    dna_project_contact: xxx
+    dna_samp_id: xxx
+    dna_sample_format: DNAStable
+    dna_sample_name: xxx
+    dna_seq_project: xxx
+    dna_seq_project_name: xxx
+    dna_seq_project_pi: xxx
+    dna_volume: 0
+    proposal_dna: xxx
+    samp_name: xxx

--- a/src/data/invalid/SampleData-jgi_mg_data-long-dna_container_id.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_data-long-dna_container_id.yaml
@@ -1,0 +1,20 @@
+jgi_mg_data:
+  - analysis_type:
+      - metagenomics
+      - metatranscriptomics
+    dna_concentration: 1.23
+    dna_cont_type: plate
+    dna_cont_well: C3
+    dna_container_id: mount_mordor_012356789
+    dna_dnase: "no"
+    dna_isolate_meth: xxx
+    dna_project_contact: xxx
+    dna_samp_id: xxx
+    dna_sample_format: DNAStable
+    dna_sample_name: xxx
+    dna_seq_project: xxx
+    dna_seq_project_name: xxx
+    dna_seq_project_pi: xxx
+    dna_volume: 0
+    proposal_dna: xxx
+    samp_name: xxx

--- a/src/data/invalid/SampleData-jgi_mg_data-negative-dna_concenctration.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_data-negative-dna_concenctration.yaml
@@ -1,0 +1,20 @@
+jgi_mg_data:
+  - analysis_type:
+      - metagenomics
+      - metatranscriptomics
+    dna_concentration: -1.23
+    dna_cont_type: plate
+    dna_cont_well: C3
+    dna_container_id: xxx
+    dna_dnase: "no"
+    dna_isolate_meth: xxx
+    dna_project_contact: xxx
+    dna_samp_id: xxx
+    dna_sample_format: DNAStable
+    dna_sample_name: xxx
+    dna_seq_project: xxx
+    dna_seq_project_name: xxx
+    dna_seq_project_pi: xxx
+    dna_volume: 0
+    proposal_dna: xxx
+    samp_name: xxx

--- a/src/data/invalid/SampleData-jgi_mg_data-string-dna_absorb2.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_data-string-dna_absorb2.yaml
@@ -1,0 +1,21 @@
+jgi_mg_data:
+  - analysis_type:
+      - metagenomics
+      - metatranscriptomics
+    dna_concentration: 1.23
+    dna_cont_type: plate
+    dna_cont_well: C3
+    dna_container_id: xxx
+    dna_dnase: "no"
+    dna_isolate_meth: xxx
+    dna_project_contact: xxx
+    dna_samp_id: xxx
+    dna_sample_format: DNAStable
+    dna_sample_name: xxx
+    dna_seq_project: xxx
+    dna_seq_project_name: xxx
+    dna_seq_project_pi: xxx
+    dna_volume: 0
+    proposal_dna: xxx
+    samp_name: xxx
+    dna_absorb2: four

--- a/src/data/unexpected_pass/SampleData-jgi_mg_data-colon-dna_sample_name.yaml
+++ b/src/data/unexpected_pass/SampleData-jgi_mg_data-colon-dna_sample_name.yaml
@@ -1,0 +1,20 @@
+jgi_mg_data:
+  - analysis_type:
+      - metagenomics
+      - metatranscriptomics
+    dna_concentration: 1.23
+    dna_cont_type: plate
+    dna_cont_well: C3
+    dna_container_id: xxx
+    dna_dnase: "no"
+    dna_isolate_meth: xxx
+    dna_project_contact: xxx
+    dna_samp_id: xxx
+    dna_sample_format: DNAStable
+    dna_sample_name: DNA:0546789 # contains colon and should not be allowed 'a-z, A-Z, 0-9, - and _ only'
+    dna_seq_project: xxx
+    dna_seq_project_name: xxx
+    dna_seq_project_pi: xxx
+    dna_volume: 0
+    proposal_dna: xxx
+    samp_name: xxx


### PR DESCRIPTION
For issue #114 : @turbomam @mslarae13  I added the jgi-mg-interface sample data files. There was one unexpected pass for the `dna_sample_name` slot. I was able to add a colon in it when it should only allow "a-z, A-Z, 0-9, - and _".