### PR TITLE
add emsl sample data

### DIFF
--- a/src/data/invalid/SampleData-emsl_data-capital-sample_type.yaml
+++ b/src/data/invalid/SampleData-emsl_data-capital-sample_type.yaml
@@ -1,0 +1,10 @@
+emsl_data:
+  - analysis_type:
+      - metagenomics
+      - metatranscriptomics
+    emsl_store_temp: -80
+    project_id: xxx
+    samp_name: xxx
+    sample_shipped: 100 units
+    sample_type: Water_extract_soil
+    replicate_number: 5

--- a/src/data/invalid/SampleData-emsl_data-string-replicate_number.yaml
+++ b/src/data/invalid/SampleData-emsl_data-string-replicate_number.yaml
@@ -1,0 +1,10 @@
+emsl_data:
+  - analysis_type:
+      - metagenomics
+      - metatranscriptomics
+    emsl_store_temp: -80
+    project_id: xxx
+    samp_name: xxx
+    sample_shipped: 100 units
+    sample_type: soil
+    replicate_number: hello

--- a/src/data/invalid/SampleData-emsl_data-string-technical_reps.yaml
+++ b/src/data/invalid/SampleData-emsl_data-string-technical_reps.yaml
@@ -1,0 +1,11 @@
+emsl_data:
+  - analysis_type:
+      - metagenomics
+      - metatranscriptomics
+    emsl_store_temp: -80
+    project_id: xxx
+    samp_name: xxx
+    sample_shipped: 100 units
+    sample_type: water_extract_soil
+    replicate_number: 5
+    technical_reps: turkey_sub


### PR DESCRIPTION
For issue #129: I added just three more invalid data files for the emslInterface class. 

I noticed a few things in the documentation:

- `replicate_number` says its range is `string`. This should be updated to say` integer`. See: https://microbiomedata.github.io/submission-schema/replicate_number/
- The same for `technical_reps`. The docs say the range is a `string` and it is actually an `integer` and is validated as such.
- Similar for `emsl_store_temp`; the docs say the range is `string` but it is validated as a `number`. See: https://microbiomedata.github.io/submission-schema/emsl_store_temp/