### PR TITLE
Ensure that project artifacts are included in wheel distribution

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -40,6 +40,7 @@ jobs:
         poetry dynamic-versioning
         make gen-project
         make project/json/nmdc_submission_schema.json
+        cp -r project src/nmdc_submission_schema
 
     - name: Build source and wheel archives
       run: poetry build

--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,8 @@ dmypy.json
 .pyre/
 
 /examples/output
+
+# A copy of the project directory is moved here
+# temporarily before `poetry build`. This is to
+# make sure we don't commit the copy.
+src/nmdc_submission_schema/project

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,12 @@ description = "The home of the NMDC submission schema. *Not* the home of sheets_
 authors = ["Mark Andrew Miller <mam@lbl.gov>"]
 license = "MIT"
 readme = "README.md"
-include = ["README.md", "src/nmdc_submission_schema/schema", "project"]
+include = [
+    # These files are copied from the top-level project folder at build time. Without
+    # the copy step they end up in a weird location when installed via wheel.
+    # See: https://github.com/python-poetry/poetry/issues/7153
+    { path = "src/nmdc_submission_schema/project/**/*", format = [ "sdist", "wheel" ] }
+]
 
 # note that the nmdc-schema is not imported as a module,
 #   but one file from the nmdc-schema is accessed via sheets_and_friends/tsv_in/import_slots_regardless.tsv


### PR DESCRIPTION
This fixes the fact that project files are not included in the wheel distribution of this package. Unlike the source distributions, Poetry doesn't make it easy to include files from _outside_ the package directory to be included in the wheel (see https://github.com/python-poetry/poetry/issues/7153). The workaround is to temporarily copy the `project` directory before doing a `poetry build`.

cc @turbomam just FYI 