### PR TITLE
Update pypi-publish workflow to take advantage of GitHub Actions' Trusted Publisher status

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -9,17 +9,23 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-latest
 
+    environment: release
+
+    permissions:
+      # this permission is mandatory for trusted publishing
+      id-token: write
+
     steps:
     - uses: actions/checkout@v2
 
     - name: Set up Python
-      uses: actions/setup-python@v2.2.2
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: '3.12'
 
     - name: Install Poetry
       run: |
-        pip install poetry==1.3.2
+        pip install poetry
         poetry self add "poetry-dynamic-versioning[plugin]"
 
     - name: Install project dependencies
@@ -46,7 +52,4 @@ jobs:
       run: poetry build
 
     - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.2.2
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_PASSWORD }}
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Fixes #191 