### PR TITLE
create `examples/output/` again

### DIFF
--- a/project.Makefile
+++ b/project.Makefile
@@ -279,8 +279,10 @@ src/data/valid/SampleData-water-data-exhaustive.yaml
 		--index-slot water_data \
 		--schema $(word 1,$^) $(word 2,$^)
 
+# todo temporary soltuion to get build and test to complete MAM 2024-07-03
 examples/output/SampleData-water-data-exhaustive.regen.yaml: src/nmdc_submission_schema/schema/nmdc_submission_schema.yaml \
 local/SampleData-water-data-exhaustive.tsv
+	mkdir -p $(dir $@) # shouldn't need to do this each time
 	$(RUN) linkml-convert \
 		--output $@ \
 		--target-class SampleData \


### PR DESCRIPTION
targets that put stuff in `examples/output/` may need to create the dir unless we change the cleanup mechanism

the absence of this dir creation step didn't seem to effect the GH Actions but it was leading to `make squeaky-clean all test` errors on my workstation