### PR TITLE
Add excel_worksheet_name annotations to DhInterface subclasses

### DIFF
--- a/schemasheets/tsv_in/classes.tsv
+++ b/schemasheets/tsv_in/classes.tsv
@@ -1,24 +1,24 @@
->key class = one DH interface	title	Desc	tree_root	parent term	yes, I am a mixin	mixins	non-imported slots
->class	title	description	tree_root	is_a	mixin	mixins	slots
->						"internal_separator: ""|"""	"internal_separator: ""|"""
-AirInterface	Air	air dh_interface		DhInterface		DhMultiviewCommonColumnsMixin|SampIdNewTermsMixin	
-BiofilmInterface	Biofilm	biofilm dh_interface		DhInterface		DhMultiviewCommonColumnsMixin|SampIdNewTermsMixin	
-BuiltEnvInterface	Built Env	built_env dh_interface		DhInterface		DhMultiviewCommonColumnsMixin|SampIdNewTermsMixin	
-EmslInterface	Emsl	emsl dh_interface		DhInterface		DhMultiviewCommonColumnsMixin	emsl_store_temp|project_id|replicate_number|sample_shipped|sample_type|technical_reps
-HcrCoresInterface	Hcr Cores	hcr_cores dh_interface		DhInterface		DhMultiviewCommonColumnsMixin	
-HcrFluidsSwabsInterface	Hcr Fluids Swabs	hcr_fluids_swabs dh_interface		DhInterface		DhMultiviewCommonColumnsMixin	
-HostAssociatedInterface	Host Associated	host_associated dh_interface		DhInterface		DhMultiviewCommonColumnsMixin|SampIdNewTermsMixin	
-JgiMgInterface	JGI MG	Metadata for samples sent to JGI for standard metagenome sequencing		DhInterface		DhMultiviewCommonColumnsMixin	dna_absorb1|dna_absorb2|dna_concentration|dna_cont_type|dna_cont_well|dna_container_id|dna_dnase|dna_isolate_meth|dna_project_contact|dna_samp_id|dna_sample_format|dna_sample_name|dna_seq_project|dna_seq_project_name|dna_seq_project_pi|dna_volume|proposal_dna
-JgiMgLrInterface	JGI MG (Long Read)	Metadata for samples sent to JGI for long read metagenome sequecning		DhInterface		DhMultiviewCommonColumnsMixin	dna_absorb1|dna_absorb2|dna_concentration|dna_cont_type|dna_cont_well|dna_container_id|dna_dnase|dna_isolate_meth|dna_project_contact|dna_samp_id|dna_sample_format|dna_sample_name|dna_seq_project|dna_seq_project_name|dna_seq_project_pi|dna_volume|proposal_dna
-JgiMtInterface	JGI MT	jgi_mt dh_interface		DhInterface		DhMultiviewCommonColumnsMixin	dnase_rna|proposal_rna|rna_absorb1|rna_absorb2|rna_concentration|rna_cont_type|rna_cont_well|rna_container_id|rna_isolate_meth|rna_project_contact|rna_samp_id|rna_sample_format|rna_sample_name|rna_seq_project|rna_seq_project_name|rna_seq_project_pi|rna_volume
-MiscEnvsInterface	Misc Envs	misc_envs dh_interface		DhInterface		DhMultiviewCommonColumnsMixin	
-PlantAssociatedInterface	Plant Associated	plant_associated dh_interface		DhInterface		DhMultiviewCommonColumnsMixin|SampIdNewTermsMixin	
-SedimentInterface	Sediment	sediment dh_interface		DhInterface		DhMultiviewCommonColumnsMixin|SampIdNewTermsMixin	
-SoilInterface	Soil	soil dh_interface		DhInterface		DhMultiviewCommonColumnsMixin|SampIdNewTermsMixin|SoilMixsInspiredMixin	
-WastewaterSludgeInterface	Wastewater Sludge	wastewater_sludge dh_interface		DhInterface		DhMultiviewCommonColumnsMixin|SampIdNewTermsMixin	
-WaterInterface	Water	water dh_interface		DhInterface		DhMultiviewCommonColumnsMixin|SampIdNewTermsMixin	
-DhMultiviewCommonColumnsMixin	Dh Mutliview Common Columns	Mixin with DhMutliviewCommon Columns			TRUE		
+>key class = one DH interface	title	Desc	tree_root	parent term	yes, I am a mixin	mixins	non-imported slots	excel sheet name
+>class	title	description	tree_root	is_a	mixin	mixins	slots	annotations
+>						"internal_separator: ""|"""	"internal_separator: ""|"""	"inner_key: ""excel_worksheet_name"""
+AirInterface	Air	air dh_interface		DhInterface		DhMultiviewCommonColumnsMixin|SampIdNewTermsMixin		air
+BiofilmInterface	Biofilm	biofilm dh_interface		DhInterface		DhMultiviewCommonColumnsMixin|SampIdNewTermsMixin		microbial mat_biofilm
+BuiltEnvInterface	Built Env	built_env dh_interface		DhInterface		DhMultiviewCommonColumnsMixin|SampIdNewTermsMixin		built environment
+EmslInterface	Emsl	emsl dh_interface		DhInterface		DhMultiviewCommonColumnsMixin	emsl_store_temp|project_id|replicate_number|sample_shipped|sample_type|technical_reps	EMSL
+HcrCoresInterface	Hcr Cores	hcr_cores dh_interface		DhInterface		DhMultiviewCommonColumnsMixin		hcr core
+HcrFluidsSwabsInterface	Hcr Fluids Swabs	hcr_fluids_swabs dh_interface		DhInterface		DhMultiviewCommonColumnsMixin		hcr fluids swab
+HostAssociatedInterface	Host Associated	host_associated dh_interface		DhInterface		DhMultiviewCommonColumnsMixin|SampIdNewTermsMixin		host-associated
+JgiMgInterface	JGI MG	Metadata for samples sent to JGI for standard metagenome sequencing		DhInterface		DhMultiviewCommonColumnsMixin	dna_absorb1|dna_absorb2|dna_concentration|dna_cont_type|dna_cont_well|dna_container_id|dna_dnase|dna_isolate_meth|dna_project_contact|dna_samp_id|dna_sample_format|dna_sample_name|dna_seq_project|dna_seq_project_name|dna_seq_project_pi|dna_volume|proposal_dna	JGI MG
+JgiMgLrInterface	JGI MG (Long Read)	Metadata for samples sent to JGI for long read metagenome sequecning		DhInterface		DhMultiviewCommonColumnsMixin	dna_absorb1|dna_absorb2|dna_concentration|dna_cont_type|dna_cont_well|dna_container_id|dna_dnase|dna_isolate_meth|dna_project_contact|dna_samp_id|dna_sample_format|dna_sample_name|dna_seq_project|dna_seq_project_name|dna_seq_project_pi|dna_volume|proposal_dna	JGI MG (Long Read)
+JgiMtInterface	JGI MT	jgi_mt dh_interface		DhInterface		DhMultiviewCommonColumnsMixin	dnase_rna|proposal_rna|rna_absorb1|rna_absorb2|rna_concentration|rna_cont_type|rna_cont_well|rna_container_id|rna_isolate_meth|rna_project_contact|rna_samp_id|rna_sample_format|rna_sample_name|rna_seq_project|rna_seq_project_name|rna_seq_project_pi|rna_volume	JGI MT
+MiscEnvsInterface	Misc Envs	misc_envs dh_interface		DhInterface		DhMultiviewCommonColumnsMixin		misc natural or artificial
+PlantAssociatedInterface	Plant Associated	plant_associated dh_interface		DhInterface		DhMultiviewCommonColumnsMixin|SampIdNewTermsMixin		plant-associated
+SedimentInterface	Sediment	sediment dh_interface		DhInterface		DhMultiviewCommonColumnsMixin|SampIdNewTermsMixin		sediment
+SoilInterface	Soil	soil dh_interface		DhInterface		DhMultiviewCommonColumnsMixin|SampIdNewTermsMixin|SoilMixsInspiredMixin		soil
+WastewaterSludgeInterface	Wastewater Sludge	wastewater_sludge dh_interface		DhInterface		DhMultiviewCommonColumnsMixin|SampIdNewTermsMixin		wastewater sludge
+WaterInterface	Water	water dh_interface		DhInterface		DhMultiviewCommonColumnsMixin|SampIdNewTermsMixin		water
+DhMultiviewCommonColumnsMixin	Dh Mutliview Common Columns	Mixin with DhMutliviewCommon Columns			TRUE
 SampIdNewTermsMixin	SampId New Terms	Mixin with SampIdNew Terms			TRUE		sample_link
 SoilMixsInspiredMixin	Soil MIxS Inspired Mixin	Mixin with SoilMixsInspired Terms			TRUE		collection_date_inc|collection_time|collection_time_inc|experimental_factor_other|filter_method|isotope_exposure|micro_biomass_c_meth|micro_biomass_n_meth|microbial_biomass_c|microbial_biomass_n|non_microb_biomass|non_microb_biomass_method|org_nitro_method|other_treatment|start_date_inc|start_time_inc
-DhInterface	Dh Root Interface	One DataHarmonizer interface, for the specified combination of a checklist, enviornmental_package, and various standards, user facilities or analysis types					
+DhInterface	Dh Root Interface	One DataHarmonizer interface, for the specified combination of a checklist, enviornmental_package, and various standards, user facilities or analysis types
 SampleData	SampleData	represents data produced by the DataHarmonizer tabs of the submission portal	TRUE				air_data|biofilm_data|built_env_data|host_associated_data|plant_associated_data|sediment_data|soil_data|wastewater_sludge_data|water_data|emsl_data|jgi_mg_lr_data|jgi_mg_data|jgi_mt_data

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,32 @@
+import unittest
+from pathlib import Path
+
+from linkml_runtime import SchemaView
+
+SCHEMA_YAML_PATH = Path(__file__).parent / "../src/nmdc_submission_schema/schema/nmdc_submission_schema.yaml"
+
+
+class TestSchema(unittest.TestCase):
+    """Tests that the schema itself is well-formed, outside any specific data instances"""
+
+    def test_excel_worksheet_name_annotations(self):
+        """Test that all DhInterface subclasses have an excel_worksheet_name annotation and that its
+        value is not longer than 31 characters, which is the maximum length of a worksheet name in
+        Excel.
+        """
+
+        schema_view = SchemaView(SCHEMA_YAML_PATH)
+        for class_name, class_def in schema_view.all_classes().items():
+            if class_def.is_a != "DhInterface":
+                continue
+
+            excel_worksheet_name_annotation = class_def.annotations.get("excel_worksheet_name")
+            self.assertIsNotNone(
+                excel_worksheet_name_annotation,
+                f"Missing excel_worksheet_name annotation for {class_name}"
+            )
+            self.assertLessEqual(
+                len(excel_worksheet_name_annotation.value),
+                31,
+                f"excel_worksheet_name \"{excel_worksheet_name_annotation.value}\" is too long"
+            )


### PR DESCRIPTION
Part of #213 (there will be further changes in `nndc-server`).

These changes add an `excel_worksheet_name` annotation to each `DhInterface` subclass. A new test verifies that these annotations exist and the values are not longer than 31 characters.

I took a closer look at using https://linkml.io/linkml-model/latest/docs/structured_aliases/ but it's unclear how to apply it here. Moreover I don't believe `schemasheets` supports it. So I think it's best to stick with `annotations` for now.

The values of the `excel_worksheet_name` annotations were chosen such that, when these changes are integrated into `nmdc-server`, existing Excel worksheets will be backwards compatible except for:

| old name | new name | reason |
| --- | --- | --- |
| hydrocarbon resources - fluids swabs | hcr fluids swab | Old name was invalid because > 31 characters
| hydrocarbon resources - cores | hcr core | Staying consistent with "hcr fluids swab"
| miscellaneous natural or artificial environment | misc natural or artificial | Old name was invalid because > 31 characters

cc: @mslarae13 