### PR TITLE
templated schema-as-yaml modifier

### DIFF
--- a/qy2-config.tsv
+++ b/qy2-config.tsv
@@ -42,3 +42,6 @@ true	slot_or_usage					delete_element	name	NULL
 true	slot_or_usage	range		string		delete_field	inlined	NULL
 true	slot_or_usage	range		string		delete_field	inlined_as_list	NULL
 true	all_elements	""		""		delete_field	text	NULL
+true	slot_or_usage	""		""	lat_lon	set	pattern	^[-+]?([1-8]?\d(\.\d{1,8})?|90(\.0{1,8})?)\s[-+]?(180(\.0{1,8})?|((1[0-7]\d)|([1-9]?\d))(\.\d{1,8})?)$
+true	slot_or_usage	range		QuantityValue			pattern	^([-+]?[0-9]*\.?[0-9]+ +\S.*\|)*([-+]?[0-9]*\.?[0-9]+ +\S.*)$
+true	slot_or_usage	string_serialization		{text};{float} {unit}			pattern	^[^;\t\r\x0A\|]+;[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)? [^;\t\r\x0A\|]+$

--- a/qy2-config.tsv
+++ b/qy2-config.tsv
@@ -47,3 +47,4 @@ rank	active	scope	criterion_field	criterion_value	criterion_in_set	element_key	o
 24	true	slot_or_usage					delete_element	name		true
 24	true	slot_or_usage	range	string			delete_field	inlined		true
 24	true	slot_or_usage	range	string			delete_field	inlined_as_list		true
+24	true	all_elements	""	""			delete_field	text		true

--- a/qy2-config.tsv
+++ b/qy2-config.tsv
@@ -1,50 +1,44 @@
-rank	active	scope	criterion_field	criterion_value	criterion_in_set	element_key	operation	target_field	target_value	success
-1	true	slot_or_usage	range	TimestampValue			set	range	string	true
-2	true	slot_or_usage	range	TextValue			set	range	string	true
-3	true	slot_or_usage	range	QuantityValue			set	range	string	true
-4	true	slot_or_usage	range	OntologyClass			set	range	string	true
-5	true	slot_or_usage	range	GeolocationValue			set	range	string	true
-6	true	slot_or_usage	range	ControlledTermValue			set	range	string	true
-7	true	slot_or_usage	range	ControlledIdentifiedTermValue			set	range	string	true
-8	true	slot_or_usage	range		enum_keys		delete_field	multivalued		true except for oxy_stat_samp
-9	true	slot_or_usage	range		type_keys		delete_field	multivalued		true
-11	true	slot_or_usage				dna_dnase	set	range	YesNoEnum	not in usages
-12	true	slot_or_usage				dnase_rna	set	range	YesNoEnum	not in usages
-13	true	slot_or_usage				oxy_stat_samp	set	range	rel_to_oxygen_enum	not in usages
-14	true	slot_or_usage				oxy_stat_samp	delete_field	multivalued
-15	true	slot_or_usage				sample_link	set	range	string	true
-16	true	slot_or_usage					delete_element	latitude		true
-17	true	slot_or_usage					delete_element	longitude		true
-18	true	slot_or_usage					delete_element	has_maximum_numeric_value		true
-19	true	slot_or_usage					delete_element	has_minimum_numeric_value		true
-20	true	slot_or_usage					delete_element	has_numeric_value		true except for some examples
-21	true	slot_or_usage					delete_element	has_raw_value		true except for some examples and comments
-22	true	slot_or_usage					delete_element	has_unit		true except for some examples
-23	true	slot_or_usage					delete_element	term		true
-24	true	class					delete_element	AttributeValue		true
-25	true	class					delete_element	ControlledIdentifiedTermValue		true
-26	true	class					delete_element	ControlledTermValue		true
-27	true	class					delete_element	GeolocationValue		true
-28	true	class					delete_element	OntologyClass		true
-29	true	class					delete_element	QuantityValue		true
-30	true	class					delete_element	TextValue		true
-31	true	class					delete_element	TimestampValue		true
-32	true	all_elements					delete_field	domain_of		true
-33	true	all_elements					delete_field	from_schema		true
-34	true	all_elements					delete_field	domain		true
-36		slot_or_usage	range		class_keys		set	range	string
-37		slot_or_usage	range	string			delete_field	multivalued
-38		slot_or_usage	range	float			delete_field	multivalued
-39		slot_or_usage	range	double			delete_field	multivalued
-40		slot_or_usage	range	integer			delete_field	multivalued
-41		slot_or_usage	range	uriorcurie			delete_field	multivalued
-42	true	all_elements					delete_field	name
-34.2	true	all_elements					delete_field	owner		true
-33	true	all_elements					delete_field	from_schema		""
-33	true	all_elements					delete_field	from_schema		""
-33	true	all_elements					delete_field	from_schema		""
-24	true	class					delete_element	NamedThing		true
-24	true	slot_or_usage					delete_element	name		true
-24	true	slot_or_usage	range	string			delete_field	inlined		true
-24	true	slot_or_usage	range	string			delete_field	inlined_as_list		true
-24	true	all_elements	""	""			delete_field	text		true
+active	scope	criterion_field	criterion_in_set	criterion_value	element_key	operation	target_field	target_value
+true	slot_or_usage	range		TimestampValue		set	range	string
+true	slot_or_usage	range		TextValue		set	range	string
+true	slot_or_usage	range		QuantityValue		set	range	string
+true	slot_or_usage	range		OntologyClass		set	range	string
+true	slot_or_usage	range		GeolocationValue		set	range	string
+true	slot_or_usage	range		ControlledTermValue		set	range	string
+true	slot_or_usage	range		ControlledIdentifiedTermValue		set	range	string
+true	slot_or_usage	range	enum_keys			delete_field	multivalued	NULL
+true	slot_or_usage	range	type_keys			delete_field	multivalued	NULL
+true	slot_or_usage				dna_dnase	set	range	YesNoEnum
+true	slot_or_usage				dnase_rna	set	range	YesNoEnum
+true	slot_or_usage				oxy_stat_samp	set	range	rel_to_oxygen_enum
+true	slot_or_usage				oxy_stat_samp	delete_field	multivalued	""
+true	slot_or_usage				sample_link	set	range	string
+true	slot_or_usage					delete_element	latitude	NULL
+true	slot_or_usage					delete_element	longitude	NULL
+true	slot_or_usage					delete_element	has_maximum_numeric_value	NULL
+true	slot_or_usage					delete_element	has_minimum_numeric_value	NULL
+true	slot_or_usage					delete_element	has_numeric_value	NULL
+true	slot_or_usage					delete_element	has_raw_value	NULL
+true	slot_or_usage					delete_element	has_unit	NULL
+true	slot_or_usage					delete_element	term	NULL
+true	class					delete_element	AttributeValue	NULL
+true	class					delete_element	ControlledIdentifiedTermValue	NULL
+true	class					delete_element	ControlledTermValue	NULL
+true	class					delete_element	GeolocationValue	NULL
+true	class					delete_element	OntologyClass	NULL
+true	class					delete_element	QuantityValue	NULL
+true	class					delete_element	TextValue	NULL
+true	class					delete_element	TimestampValue	NULL
+true	all_elements					delete_field	domain_of	NULL
+true	all_elements					delete_field	from_schema	NULL
+true	all_elements					delete_field	domain	NULL
+true	all_elements					delete_field	name	""
+true	all_elements					delete_field	owner	NULL
+true	all_elements					delete_field	from_schema	NULL
+true	all_elements					delete_field	from_schema	NULL
+true	all_elements					delete_field	from_schema	NULL
+true	class					delete_element	NamedThing	NULL
+true	slot_or_usage					delete_element	name	NULL
+true	slot_or_usage	range		string		delete_field	inlined	NULL
+true	slot_or_usage	range		string		delete_field	inlined_as_list	NULL
+true	all_elements	""		""		delete_field	text	NULL

--- a/qy2-config.tsv
+++ b/qy2-config.tsv
@@ -1,0 +1,49 @@
+rank	active	scope	criterion_field	criterion_value	criterion_in_set	element_key	operation	target_field	target_value	success
+1	true	slot_or_usage	range	TimestampValue			set	range	string	true
+2	true	slot_or_usage	range	TextValue			set	range	string	true
+3	true	slot_or_usage	range	QuantityValue			set	range	string	true
+4	true	slot_or_usage	range	OntologyClass			set	range	string	true
+5	true	slot_or_usage	range	GeolocationValue			set	range	string	true
+6	true	slot_or_usage	range	ControlledTermValue			set	range	string	true
+7	true	slot_or_usage	range	ControlledIdentifiedTermValue			set	range	string	true
+8	true	slot_or_usage	range		enum_keys		delete_field	multivalued		true except for oxy_stat_samp
+9	true	slot_or_usage	range		type_keys		delete_field	multivalued		true
+11	true	slot_or_usage				dna_dnase	set	range	YesNoEnum	not in usages
+12	true	slot_or_usage				dnase_rna	set	range	YesNoEnum	not in usages
+13	true	slot_or_usage				oxy_stat_samp	set	range	rel_to_oxygen_enum	not in usages
+14	true	slot_or_usage				oxy_stat_samp	delete_field	multivalued
+15	true	slot_or_usage				sample_link	set	range	string	true
+16	true	slot_or_usage					delete_element	latitude		true
+17	true	slot_or_usage					delete_element	longitude		true
+18	true	slot_or_usage					delete_element	has_maximum_numeric_value		true
+19	true	slot_or_usage					delete_element	has_minimum_numeric_value		true
+20	true	slot_or_usage					delete_element	has_numeric_value		true except for some examples
+21	true	slot_or_usage					delete_element	has_raw_value		true except for some examples and comments
+22	true	slot_or_usage					delete_element	has_unit		true except for some examples
+23	true	slot_or_usage					delete_element	term		true
+24	true	class					delete_element	AttributeValue		true
+25	true	class					delete_element	ControlledIdentifiedTermValue		true
+26	true	class					delete_element	ControlledTermValue		true
+27	true	class					delete_element	GeolocationValue		true
+28	true	class					delete_element	OntologyClass		true
+29	true	class					delete_element	QuantityValue		true
+30	true	class					delete_element	TextValue		true
+31	true	class					delete_element	TimestampValue		true
+32	true	all_elements					delete_field	domain_of		true
+33	true	all_elements					delete_field	from_schema		true
+34	true	all_elements					delete_field	domain		true
+36		slot_or_usage	range		class_keys		set	range	string
+37		slot_or_usage	range	string			delete_field	multivalued
+38		slot_or_usage	range	float			delete_field	multivalued
+39		slot_or_usage	range	double			delete_field	multivalued
+40		slot_or_usage	range	integer			delete_field	multivalued
+41		slot_or_usage	range	uriorcurie			delete_field	multivalued
+42	true	all_elements					delete_field	name
+34.2	true	all_elements					delete_field	owner		true
+33	true	all_elements					delete_field	from_schema		""
+33	true	all_elements					delete_field	from_schema		""
+33	true	all_elements					delete_field	from_schema		""
+24	true	class					delete_element	NamedThing		true
+24	true	slot_or_usage					delete_element	name		true
+24	true	slot_or_usage	range	string			delete_field	inlined		true
+24	true	slot_or_usage	range	string			delete_field	inlined_as_list		true

--- a/src/nmdc_submission_schema/scripts/qy2.py
+++ b/src/nmdc_submission_schema/scripts/qy2.py
@@ -201,7 +201,7 @@ def main(schema: str, config: str, output: str, collapse_annotations: bool, drop
                             # click.echo(f"setting {ak} to {av}")
                             if 'tag' in av and 'value' in av:
                                 # click.echo(f"setting {ak} to {av['value']} for {sk}")
-                                sv['annotations'][ak] = av['tag']
+                                sv['annotations'][ak] = av['value']
                     if drop_redundant_aliases and 'aliases' in sv:
                         current_aliases = sv['aliases']
                         for alias in sv['aliases']:
@@ -246,7 +246,7 @@ def main(schema: str, config: str, output: str, collapse_annotations: bool, drop
                             # click.echo(f"setting {ak} to {av}")
                             if 'tag' in av and 'value' in av:
                                 # click.echo(f"setting {ak} to {av['value']} for {sk}")
-                                cv['annotations'][ak] = av['tag']
+                                cv['annotations'][ak] = av['value']
             if ok == 'classes' \
                     and scope in ['usage', 'slot_or_usage', 'all_elements']:
                 for ck, cv in ov.items():  # c for class
@@ -294,7 +294,7 @@ def main(schema: str, config: str, output: str, collapse_annotations: bool, drop
                                     # click.echo(f"setting {ak} to {av}")
                                     if 'tag' in av and 'value' in av:
                                         # click.echo(f"setting {ak} to {av['value']} for {sk}")
-                                        sv['annotations'][ak] = av['tag']
+                                        sv['annotations'][ak] = av['value']
                             if drop_redundant_aliases and 'aliases' in sv:
                                 current_aliases = sv['aliases']
                                 for alias in sv['aliases']:
@@ -340,7 +340,7 @@ def main(schema: str, config: str, output: str, collapse_annotations: bool, drop
                             # click.echo(f"setting {ak} to {av}")
                             if 'tag' in av and 'value' in av:
                                 # click.echo(f"setting {ak} to {av['value']} for {sk}")
-                                ev['annotations'][ak] = av['tag']
+                                ev['annotations'][ak] = av['value']
                     if 'permissible_values' in ev:
                         for vk, vv in ev['permissible_values'].items():
                             # click.echo(f"checking permissible value {vk} in enum {ek}")
@@ -350,7 +350,7 @@ def main(schema: str, config: str, output: str, collapse_annotations: bool, drop
                                     # click.echo(f"setting {ak} to {av}")
                                     if 'tag' in av and 'value' in av:
                                         # click.echo(f"setting {ak} to {av['value']} for {sk}")
-                                        vv['annotations'][ak] = av['tag']
+                                        vv['annotations'][ak] = av['value']
                             if criterion_field == "" \
                                     and criterion_in_set == "" \
                                     and criterion_value == "" \

--- a/src/nmdc_submission_schema/scripts/qy2.py
+++ b/src/nmdc_submission_schema/scripts/qy2.py
@@ -1,0 +1,361 @@
+import csv
+
+import yaml
+from glom import glom, assign
+import click
+from typing import Dict, Any, Optional, List
+import re
+from typing import Dict, Any
+import click
+
+
+def load_yaml(file_path: str) -> Dict[str, Any]:
+    """Load a YAML file and return its content as a dictionary."""
+    with open(file_path, 'r') as file:
+        return yaml.safe_load(file)
+
+
+def load_tsv(file_path: str) -> List[Dict[str | Any, str | Any]]:
+    """Load a TSV file and return its content as a list of dictionaries."""
+    with open(file_path, mode='r', newline='') as file:
+        reader = csv.DictReader(file, delimiter='\t')
+        return [row for row in reader]  # Convert reader to a list of dictionaries
+
+
+def save_yaml(data: Dict[str, Any], file_path: str) -> None:
+    """Save a dictionary to a YAML file."""
+    with open(file_path, 'w') as file:
+        yaml.safe_dump(data, file)
+
+
+@click.command()
+@click.option("--schema", required=True, type=click.Path(exists=True), help="Path to the input YAML file.")
+@click.option("--config", required=True, type=click.Path(exists=True),
+              help="Path to the TSV configuration file specifying modifications.")
+@click.option("--output", required=True, type=click.Path(), help="Path to save the modified YAML file.")
+def main(schema: str, config: str, output: str) -> None:
+    """
+    Modify the input YAML based on rules in the config file and save the result to the output file.
+
+    Args:
+        schema (str): Path to the input YAML file.
+        config (str): Path to the configuration file specifying modifications.
+        output (str): Path to save the modified YAML file.
+    """
+    # Load input data and configuration
+    schema = load_yaml(schema)
+
+    enums = schema.get("enums", {})
+    enum_keys = set(enums.keys())  # Collect the keys for quick lookup
+    types = schema.get("types", {})
+    type_keys = set(types.keys())
+    classes = schema.get("classes", {})
+    class_keys = set(classes.keys())
+    sets = dict()
+    sets['enum_keys'] = enum_keys
+    sets['type_keys'] = type_keys
+    sets['class_keys'] = class_keys
+    sets_keys = set(sets.keys())
+
+    raw_config = load_tsv(config)
+
+    for rc in raw_config:
+        scope = rc.get('scope')
+        criterion_field = rc.get('criterion_field')
+        criterion_value = rc.get('criterion_value')
+        criterion_in_set = rc.get('criterion_in_set')
+        operation = rc.get('operation')
+        target_field = rc.get('target_field')
+        target_value = rc.get('target_value')
+        element_key = rc.get('element_key')
+        active = rc.get('active')
+        # make active uppercase
+        if active.upper() != "TRUE":
+            continue
+
+        if operation == 'set' \
+                and criterion_field == "" \
+                and criterion_in_set == "" \
+                and criterion_value == "" \
+                and element_key in schema['slots'] \
+                and scope in ['slot', 'slot_or_usage'] \
+                and target_field in schema['slots'][element_key]:
+            schema['slots'][element_key][target_field] = target_value
+
+        if operation == 'delete_element' \
+                and criterion_field == "" \
+                and criterion_in_set == "" \
+                and criterion_value == "" \
+                and element_key == "" \
+                and scope in ['slot', 'slot_or_usage'] \
+                and target_field in schema['slots']:
+            del schema['slots'][target_field]
+
+        for ck, cv in schema['classes'].items():
+            if 'slots' in cv:
+                slots_list = cv['slots']
+                if operation == 'delete_element' \
+                        and criterion_field == "" \
+                        and criterion_in_set == "" \
+                        and criterion_value == "" \
+                        and element_key == "" \
+                        and scope in ['usage', 'slot_or_usage'] \
+                        and target_field in slots_list:
+                    slots_list.remove(target_field)
+            if 'slot_usage' in cv:
+                if operation == 'delete_element' \
+                        and criterion_field == "" \
+                        and criterion_in_set == "" \
+                        and criterion_value == "" \
+                        and element_key == "" \
+                        and scope in ['usage', 'slot_or_usage'] \
+                        and target_field in cv['slot_usage']:
+                    del cv['slot_usage'][target_field]
+                if operation == 'set' \
+                        and criterion_field == "" \
+                        and criterion_in_set == "" \
+                        and criterion_value == "" \
+                        and element_key in cv['slot_usage'] \
+                        and scope in ['usage', 'slot_or_usage'] \
+                        and target_field in cv['slot_usage'][element_key]:
+                    cv['slot_usage'][element_key][target_field] = target_value
+
+        if operation == 'delete_element' \
+                and criterion_field == "" \
+                and criterion_in_set == "" \
+                and criterion_value == "" \
+                and element_key == "" \
+                and scope in ['class'] \
+                and target_field in schema['classes']:
+            del schema['classes'][target_field]
+
+        for ok, ov in schema.items():  # o for outer
+            # print(ok)
+            #
+            # types
+            #
+            # classes
+            # enums
+            # slots
+            # subsets
+            if ok == 'slots' \
+                    and scope in ['slot', 'slot_or_usage', 'all_elements']:
+                for sk, sv in ov.items():  # s for slot
+                    if criterion_field in sv \
+                            and criterion_in_set == "" \
+                            and element_key == "" \
+                            and operation == 'set' \
+                            and sv[criterion_field] == criterion_value:
+                        # click.echo(
+                        #     f"setting {target_field} to {target_value} in slot {sk} because {criterion_field} == {criterion_value}")
+                        sv[target_field] = target_value
+                    if criterion_field in sv \
+                            and criterion_value == "" \
+                            and element_key == "" \
+                            and operation == 'delete_field' \
+                            and sv[criterion_field] in sets[criterion_in_set] \
+                            and target_field in sv \
+                            and target_value == "":
+                        click.echo(
+                            f"deleting {target_field} in slot {sk} because {sv[criterion_field]} is in {criterion_in_set}")
+                        del sv[target_field]
+                    if criterion_field == "" \
+                            and criterion_in_set == "" \
+                            and criterion_value == "" \
+                            and element_key == "" \
+                            and operation == 'delete_field' \
+                            and target_field in sv:
+                        # click.echo(f"globally deleting {target_field} in slot {sk}")
+                        del sv[target_field]
+                    if sk == element_key \
+                            and criterion_field == "" \
+                            and criterion_in_set == "" \
+                            and criterion_value == "" \
+                            and operation == 'set':
+                        # click.echo(f"setting {target_field} to {target_value} in slot {sk}")
+                        sv[target_field] = target_value
+                    if sk == element_key \
+                            and criterion_field == "" \
+                            and criterion_in_set == "" \
+                            and criterion_value == "" \
+                            and operation == 'delete_field' \
+                            and target_field in sv:
+                        click.echo(f"deleting {target_field} in slot {sk}")
+                        del sv[target_field]
+                    if criterion_field in sv \
+                            and element_key == "" \
+                            and operation == 'delete_field' \
+                            and sv[criterion_field] == criterion_value \
+                            and target_field in sv \
+                            and target_value == "":
+                        click.echo(
+                            f"deleting {target_field} in slot {sk} because {sv[criterion_field]} == {criterion_value}")
+                        del sv[target_field]
+            if ok == 'classes' \
+                    and scope in ['class', 'all_elements']:
+                for ck, cv in ov.items():  # c for class
+                    if criterion_field in cv \
+                            and criterion_in_set == "" \
+                            and element_key == "" \
+                            and operation == 'set' \
+                            and cv[criterion_field] == criterion_value:
+                        click.echo(
+                            f"setting {target_field} to {target_value} in class {ck} because {criterion_field} == {criterion_value}")
+                        cv[target_field] = target_value
+                    if criterion_field in cv \
+                            and criterion_value == "" \
+                            and element_key == "" \
+                            and operation == 'delete_field' \
+                            and cv[criterion_field] in sets[criterion_in_set] \
+                            and target_field in cv \
+                            and target_value == "":
+                        click.echo(
+                            f"deleting {target_field} in class {ck}  because {cv[criterion_field]} is in {criterion_in_set}")
+                        del cv[target_field]
+                    if criterion_field == "" \
+                            and criterion_in_set == "" \
+                            and criterion_value == "" \
+                            and element_key == "" \
+                            and operation == 'delete_field' \
+                            and target_field in cv:
+                        # click.echo(f"globally deleting {target_field} in class {ck}")
+                        del cv[target_field]
+            if ok == 'classes' \
+                    and scope in ['usage', 'slot_or_usage', 'all_elements']:
+                for ck, cv in ov.items():  # c for class
+                    if 'slot_usage' in cv:
+                        for sk, sv in cv['slot_usage'].items():
+                            # click.echo(f"checking slot_usage in class {ck} slot {sk}")
+                            if criterion_field in sv \
+                                    and criterion_in_set == "" \
+                                    and element_key == "" \
+                                    and operation == 'set' \
+                                    and sv[criterion_field] == criterion_value:
+                                # click.echo(
+                                #     f"setting {target_field} to {target_value} in class {ck} usage of slot {sk} because {criterion_field} == {criterion_value}")
+                                sv[target_field] = target_value
+                            if criterion_field in sv \
+                                    and criterion_value == "" \
+                                    and element_key == "" \
+                                    and operation == 'delete_field' \
+                                    and sv[criterion_field] in sets[criterion_in_set] \
+                                    and target_field in sv \
+                                    and target_value == "":
+                                # click.echo(
+                                #     f"deleting {target_field} in class {ck} usage {sk} because {sv[criterion_field]} is in {criterion_in_set}")
+                                del sv[target_field]
+                            if criterion_field == "" \
+                                    and criterion_in_set == "" \
+                                    and criterion_value == "" \
+                                    and element_key == "" \
+                                    and operation == 'delete_field' \
+                                    and target_field in sv:
+                                # click.echo(f"globally deleting {target_field} in class {ck} usage {sk}")
+                                del sv[target_field]
+                            if criterion_field in sv \
+                                    and element_key == "" \
+                                    and operation == 'delete_field' \
+                                    and sv[criterion_field] == criterion_value \
+                                    and target_field in sv \
+                                    and target_value == "":
+                                # click.echo(
+                                #     f"deleting {target_field} in {ck} usage {sk} because {sv[criterion_field]} == {criterion_value}")
+                                del sv[target_field]
+            if ok == 'enums' \
+                    and scope in ['enum', 'all_elements']:
+                for ek, ev in ov.items():
+                    # click.echo(f"checking enum {ek}")
+                    if criterion_field in ev \
+                            and criterion_in_set == "" \
+                            and element_key == "" \
+                            and operation == 'set' \
+                            and ev[criterion_field] == criterion_value:
+                        click.echo(
+                            f"setting {target_field} to {target_value} in enum {ek} because {criterion_field} == {criterion_value}")
+                        ev[target_field] = target_value
+                    if criterion_field in ev \
+                            and criterion_value == "" \
+                            and element_key == "" \
+                            and operation == 'delete_field' \
+                            and ev[criterion_field] in sets[criterion_in_set] \
+                            and target_field in ev \
+                            and target_value == "":
+                        click.echo(
+                            f"deleting {target_field} in enum {ek} because {ek[criterion_field]} is in {criterion_in_set}")
+                        del ev[target_field]
+                    if criterion_field == "" \
+                            and criterion_in_set == "" \
+                            and criterion_value == "" \
+                            and element_key == "" \
+                            and operation == 'delete_field' \
+                            and target_field in ev:
+                        # click.echo(f"globally deleting {target_field} in enum {ek}")
+                        del ev[target_field]
+            if ok == 'subsets' \
+                    and scope in ['all_elements']:
+                for uk, uv in ov.items():
+                    # click.echo(f"checking subset {uk}")
+                    if criterion_field in uv \
+                            and criterion_in_set == "" \
+                            and element_key == "" \
+                            and operation == 'set' \
+                            and uv[criterion_field] == criterion_value:
+                        click.echo(
+                            f"setting {target_field} to {target_value} in subset {uk} because {criterion_field} == {criterion_value}")
+                        uv[target_field] = target_value
+                    if criterion_field in uv \
+                            and criterion_value == "" \
+                            and element_key == "" \
+                            and operation == 'delete_field' \
+                            and uv[criterion_field] in sets[criterion_in_set] \
+                            and target_field in uv \
+                            and target_value == "":
+                        click.echo(
+                            f"deleting {target_field} in subset {uk} because {uk[criterion_field]} is in {criterion_in_set}")
+                        del uv[target_field]
+                    if criterion_field == "" \
+                            and criterion_in_set == "" \
+                            and criterion_value == "" \
+                            and element_key == "" \
+                            and operation == 'delete_field' \
+                            and target_field in uv:
+                        # click.echo(f"globally deleting {target_field} in subset {uk}")
+                        del uv[target_field]
+            if ok == 'types' \
+                    and scope in ['all_elements']:  # or might want to remove all linkml types and add an import
+                for tk, tv in ov.items():
+                    # click.echo(f"checking type {tk}")
+                    if criterion_field in tv \
+                            and criterion_in_set == "" \
+                            and element_key == "" \
+                            and operation == 'set' \
+                            and tv[criterion_field] == criterion_value:
+                        click.echo(
+                            f"setting {target_field} to {target_value} in type {tk} because {criterion_field} == {criterion_value}")
+                        tv[target_field] = target_value
+                    if criterion_field in tv \
+                            and criterion_value == "" \
+                            and element_key == "" \
+                            and operation == 'delete_field' \
+                            and tv[criterion_field] in sets[criterion_in_set] \
+                            and target_field in tv \
+                            and target_value == "":
+                        click.echo(
+                            f"deleting {target_field} in type {tk} because {tk[criterion_field]} is in {criterion_in_set}")
+                        del tv[target_field]
+                    if criterion_field == "" \
+                            and criterion_in_set == "" \
+                            and criterion_value == "" \
+                            and element_key == "" \
+                            and operation == 'delete_field' \
+                            and target_field in tv:
+                        # click.echo(f"globally deleting {target_field} in type {tk}")
+                        del tv[target_field]
+
+    # Save the modified data to the output file
+    save_yaml(schema, output)
+    # click.echo(f"Modifications applied to {input_yaml} and saved to {output_file} as per {config_file}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nmdc_submission_schema/scripts/qy2.py
+++ b/src/nmdc_submission_schema/scripts/qy2.py
@@ -1,3 +1,6 @@
+# todo: handle any_of (optionally?)
+#  deduplicate lists like comments or slots
+
 import csv
 import pprint
 
@@ -77,7 +80,7 @@ def main(schema: str, config: str, output: str, collapse_annotations: bool, drop
         if drop_redundant_aliases and 'aliases' in sv:
             current_aliases = sv['aliases']
             for alias in sv['aliases']:
-                if 'title' in sv and alias == sv['title']:
+                if ('title' in sv and alias == sv['title']) or alias == sk:
                     # click.echo(f"removing redundant alias {alias} from slot {sk}")
                     current_aliases.remove(alias)
             if len(current_aliases) == 0:
@@ -93,8 +96,10 @@ def main(schema: str, config: str, output: str, collapse_annotations: bool, drop
         if drop_redundant_aliases and 'aliases' in cv:
             current_aliases = cv['aliases']
             for alias in cv['aliases']:
-                if 'title' in cv and alias == cv['title']:
+                if ('title' in cv and alias == sv['title']) or alias == ck:
                     click.echo(f"removing redundant alias {alias} from {ck}")
+                    current_aliases.remove(alias)
+                if alias == ck:
                     current_aliases.remove(alias)
             if len(current_aliases) == 0:
                 del cv['aliases']
@@ -110,9 +115,11 @@ def main(schema: str, config: str, output: str, collapse_annotations: bool, drop
                 if drop_redundant_aliases and 'aliases' in sv:
                     current_aliases = sv['aliases']
                     for alias in sv['aliases']:
-                        if 'title' in sv and alias == sv['title']:
+                        if ('title' in sv and alias == sv['title']) or alias == sk:
                             # click.echo(f"removing redundant alias {alias} from slot {sk} in {ck}")
                             current_aliases.remove(alias)
+                        # if alias == sk:
+                        #     current_aliases.remove(alias)
                     if len(current_aliases) == 0:
                         del sv['aliases']
                     else:
@@ -127,9 +134,11 @@ def main(schema: str, config: str, output: str, collapse_annotations: bool, drop
         if drop_redundant_aliases and 'aliases' in ev:
             current_aliases = ev['aliases']
             for alias in ev['aliases']:
-                if 'title' in ev and alias == ev['title']:
+                if ('title' in ev and alias == sv['title']) or alias == ek:
                     click.echo(f"removing redundant alias {alias} from {ek}")
                     current_aliases.remove(alias)
+                # if alias == ek:
+                #     current_aliases.remove(alias)
             if len(current_aliases) == 0:
                 del ev['aliases']
             else:
@@ -144,9 +153,11 @@ def main(schema: str, config: str, output: str, collapse_annotations: bool, drop
                 if drop_redundant_aliases and 'aliases' in vv:
                     current_aliases = vv['aliases']
                     for alias in vv['aliases']:
-                        if 'title' in vv and alias == vv['title']:
+                        if ('title' in vv and alias == sv['title']) or alias == vk:
                             click.echo(f"removing redundant alias {alias} from {vk} in {ek}")
                             current_aliases.remove(alias)
+                        # if alias == vk:
+                        #     current_aliases.remove(alias)
                     if len(current_aliases) == 0:
                         del vv['aliases']
                     else:
@@ -223,7 +234,7 @@ def main(schema: str, config: str, output: str, collapse_annotations: bool, drop
             del schema['classes'][target_field]
 
         for ok, ov in schema.items():  # o for outer
-            # print(ok)
+            # click.echo(ok)
             #
             # types
             #
@@ -375,8 +386,8 @@ def main(schema: str, config: str, output: str, collapse_annotations: bool, drop
                                     and operation == 'set' \
                                     and sv[criterion_field] == criterion_value \
                                     and target_field not in emptyish:
-                                click.echo(
-                                    f"setting {target_field} to {target_value} in class {ck} usage {sk} because {criterion_field} == {criterion_value}")
+                                # click.echo(
+                                #     f"setting {target_field} to {target_value} in class {ck} usage {sk} because {criterion_field} == {criterion_value}")
                                 sv[target_field] = target_value
                             if sk == element_key \
                                     and criterion_field in emptyish \


### PR DESCRIPTION
To replace the vast majority of the uses of `yq` in this and potentially other schemas

example run:

```shell
poetry run python src/nmdc_submission_schema/scripts/qy2.py \
    --schema local/with_shuttles.yaml 
    --config qy2-config.tsv 
    --output qy2-output.yaml 
```

## current weaknesses:

- highly repetitive linear code. needs refactoring. `src/nmdc_submission_schema/scripts/qy2.py`
- are there opportunities for integrating with the modifications or validation updating phases of sheets_and_friends' `modifications_and_validation`?
- config file `qy2-config.tsv` in repo root
- have been sending output to repo root. will obviously change that in the makefile, but in the mean time it leads to slow re-indexing by PyCharm (put the output in a non-indexed directory!)
- several different kinds of empty-ish values are currently in the configuration sheet, so testing for "", "NULL" and `None`
- the `active` column in the config file is only getting tested for 'TRUE' after upper-casing. not testing for other true-ish values

## opportunities
- convert more kinds of dicts to simple collection format, like prefixes
- remove types that could be imported from linkml and then assert the import
    - there are some things that aren't discovered as dependencies in the shuttle phase, like types, so those are in the base schema file 


probably won't be  able to support setting a list of examples like

```shell
yq '(.classes.[].slot_usage.[] | select(.name=="chem_administration") | .examples) = [{"value": "agar [CHEBI:2509];2018-05-11|agar [CHEBI:2509];2018-05-22"}, {"value": "agar [CHEBI:2509];2018-05"}]'

yq -i '(.classes.[].slot_usage.[] | select(.string_serialization=="{text};{float} {unit}" and .multivalued == true ) | .pattern) = "^([^;\t\r\x0A]+;[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)? [^;\t\r\x0A]+\|)*([^;\t\r\x0A]+;[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)? [^;\t\r\x0A]+)$'
```

probably won't be able to act on multiple criteria like

```shell
yq '(.classes.[].slot_usage.[] | select(.range == "QuantityValue" and .multivalued == true)  | .pattern) = "^([-+]?[0-9]*\.?[0-9]+ +\S.*\|)*([-+]?[0-9]*\.?[0-9]+ +\S.*)$"'
```

probably won't be able to assign or migrate rules like

```shell
yq eval-all \
    'select(fileIndex==1).classes.JgiMgInterface.rules = select(fileIndex==0).classes.Biosample.rules | select(fileIndex==1)' \
    local/nmdc.yaml $@.raw | cat > $@.raw2
yq eval-all \
    'select(fileIndex==1).classes.JgiMtInterface.rules = select(fileIndex==0).classes.Biosample.rules | select(fileIndex==1)' \
    local/nmdc.yaml $@.raw2 | cat > $@.raw
```

in addition to that, probably won't be able to act on wildcards

```shell
yq -i 'del(.classes.JgiMgInterface.rules.[] | select(.title == "rna*"))' $@.raw
yq -i 'del(.classes.JgiMtInterface.rules.[] | select(.title == "dna*"))' $@.raw
```