### PR TITLE
Synchronize `JGISampleFormatEnum` with JGI's allowed values

### DIFF
--- a/src/data/invalid/SampleData-jgi_mg_data-bad-dna_cont_type.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_data-bad-dna_cont_type.yaml
@@ -9,7 +9,7 @@ jgi_mg_data:
     dnase: "no"
     dna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/invalid/SampleData-jgi_mg_data-bad-dna_cont_well.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_data-bad-dna_cont_well.yaml
@@ -9,7 +9,7 @@ jgi_mg_data:
     dnase: "no"
     dna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/invalid/SampleData-jgi_mg_data-bad-dna_dnase.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_data-bad-dna_dnase.yaml
@@ -9,7 +9,7 @@ jgi_mg_data:
     dnase: false
     dna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/invalid/SampleData-jgi_mg_data-bad-dna_volume.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_data-bad-dna_volume.yaml
@@ -9,7 +9,7 @@ jgi_mg_data:
     dnase: "no"
     dna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/invalid/SampleData-jgi_mg_data-capital-dna_dnase.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_data-capital-dna_dnase.yaml
@@ -9,7 +9,7 @@ jgi_mg_data:
     dnase: "No"
     dna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/invalid/SampleData-jgi_mg_data-colon-dna_sample_name.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_data-colon-dna_sample_name.yaml
@@ -9,7 +9,7 @@ jgi_mg_data:
     dnase: "no"
     dna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: DNA:0546789 # description says "Sample names must ... contain a-z, A-Z, 0-9, - and _ only." but there's no patten constraint
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/invalid/SampleData-jgi_mg_data-dna_collect_site.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_data-dna_collect_site.yaml
@@ -10,7 +10,7 @@ jgi_mg_data:
     dnase: "no"
     dna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/invalid/SampleData-jgi_mg_data-dna_organisms.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_data-dna_organisms.yaml
@@ -9,7 +9,7 @@ jgi_mg_data:
     dnase: "no"
     dna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/invalid/SampleData-jgi_mg_data-high-dna_concentration.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_data-high-dna_concentration.yaml
@@ -9,7 +9,7 @@ jgi_mg_data:
     dnase: "no"
     dna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/invalid/SampleData-jgi_mg_data-illegal-string-dna_absorb1.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_data-illegal-string-dna_absorb1.yaml
@@ -9,7 +9,7 @@ jgi_mg_data:
     dnase: "no"
     dna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/invalid/SampleData-jgi_mg_data-illegal-string-dna_concentration.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_data-illegal-string-dna_concentration.yaml
@@ -9,7 +9,7 @@ jgi_mg_data:
     dnase: "no"
     dna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/invalid/SampleData-jgi_mg_data-in-bucket.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_data-in-bucket.yaml
@@ -8,7 +8,7 @@ jgi_mg_data:
     dnase: "no"
     dna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/invalid/SampleData-jgi_mg_data-in-plate-invalid-well.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_data-in-plate-invalid-well.yaml
@@ -9,7 +9,7 @@ jgi_mg_data:
     dnase: "no"
     dna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/invalid/SampleData-jgi_mg_data-in-plate-missing-well.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_data-in-plate-missing-well.yaml
@@ -8,7 +8,7 @@ jgi_mg_data:
     dnase: "no"
     dna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/invalid/SampleData-jgi_mg_data-in-tube-with-well.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_data-in-tube-with-well.yaml
@@ -9,7 +9,7 @@ jgi_mg_data:
     dnase: "no"
     dna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/invalid/SampleData-jgi_mg_data-long-dna_container_id.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_data-long-dna_container_id.yaml
@@ -9,7 +9,7 @@ jgi_mg_data:
     dnase: "no"
     dna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/invalid/SampleData-jgi_mg_data-missing-dna_cont_type.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_data-missing-dna_cont_type.yaml
@@ -7,7 +7,7 @@ jgi_mg_data:
     dnase: "no"
     dna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/invalid/SampleData-jgi_mg_data-negative-dna_concenctration.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_data-negative-dna_concenctration.yaml
@@ -9,7 +9,7 @@ jgi_mg_data:
     dnase: "no"
     dna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/invalid/SampleData-jgi_mg_data-string-dna_absorb2.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_data-string-dna_absorb2.yaml
@@ -9,7 +9,7 @@ jgi_mg_data:
     dnase: "no"
     dna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/invalid/SampleData-jgi_mg_lr_data-dna_absorb1-missing.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_lr_data-dna_absorb1-missing.yaml
@@ -9,7 +9,7 @@ jgi_mg_lr_data:
     dnase: "no"
     dna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/invalid/SampleData-jgi_mg_lr_data-dna_absorb2-missing.yaml
+++ b/src/data/invalid/SampleData-jgi_mg_lr_data-dna_absorb2-missing.yaml
@@ -9,7 +9,7 @@ jgi_mg_lr_data:
     dnase: "no"
     dna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/invalid/SampleData-jgi_mt_data-in-bucket.yaml
+++ b/src/data/invalid/SampleData-jgi_mt_data-in-bucket.yaml
@@ -8,7 +8,7 @@ jgi_mt_data:
     dnase: "no"
     rna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/invalid/SampleData-jgi_mt_data-in-plate-invalid-well-val.yaml
+++ b/src/data/invalid/SampleData-jgi_mt_data-in-plate-invalid-well-val.yaml
@@ -9,7 +9,7 @@ jgi_mt_data:
     dnase: "no"
     rna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/invalid/SampleData-jgi_mt_data-in-plate-missing-well-val.yaml
+++ b/src/data/invalid/SampleData-jgi_mt_data-in-plate-missing-well-val.yaml
@@ -8,7 +8,7 @@ jgi_mt_data:
     dnase: "no"
     rna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/invalid/SampleData-jgi_mt_data-in-tube-with-well-val.yaml
+++ b/src/data/invalid/SampleData-jgi_mt_data-in-tube-with-well-val.yaml
@@ -9,7 +9,7 @@ jgi_mt_data:
     dnase: "no"
     rna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/valid/SampleData-jgi_mg_data-exhaustive.yaml
+++ b/src/data/valid/SampleData-jgi_mg_data-exhaustive.yaml
@@ -13,7 +13,7 @@ jgi_mg_data:
     dna_isolate_meth: xxx
 #    dna_organisms: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/valid/SampleData-jgi_mg_data-in-plate-valid-well-val.yaml
+++ b/src/data/valid/SampleData-jgi_mg_data-in-plate-valid-well-val.yaml
@@ -9,7 +9,7 @@ jgi_mg_data:
     dnase: "no"
     dna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/valid/SampleData-jgi_mg_data-in-tube.yaml
+++ b/src/data/valid/SampleData-jgi_mg_data-in-tube.yaml
@@ -8,7 +8,7 @@ jgi_mg_data:
     dnase: "no"
     dna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/valid/SampleData-jgi_mg_data-minimal.yaml
+++ b/src/data/valid/SampleData-jgi_mg_data-minimal.yaml
@@ -9,7 +9,7 @@ jgi_mg_data:
     dnase: "no"
     dna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/valid/SampleData-jgi_mg_lr_data-minimal.yaml
+++ b/src/data/valid/SampleData-jgi_mg_lr_data-minimal.yaml
@@ -10,7 +10,7 @@ jgi_mg_lr_data:
     dnase: "no"
     dna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/valid/SampleData-jgi_mt_data-in-plate-valid-well-val.yaml
+++ b/src/data/valid/SampleData-jgi_mt_data-in-plate-valid-well-val.yaml
@@ -9,7 +9,7 @@ jgi_mt_data:
     dnase: "no"
     rna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/data/valid/SampleData-jgi_mt_data-in-tube.yaml
+++ b/src/data/valid/SampleData-jgi_mt_data-in-tube.yaml
@@ -8,7 +8,7 @@ jgi_mt_data:
     dnase: "no"
     rna_isolate_meth: xxx
     jgi_samp_id: xxx
-    jgi_sample_format: DNAStable
+    jgi_sample_format: Ethanol
     jgi_sample_name: xxx
     jgi_seq_project: 111
     jgi_seq_project_name: xxx

--- a/src/nmdc_submission_schema/schema/nmdc_submission_schema_base.yaml
+++ b/src/nmdc_submission_schema/schema/nmdc_submission_schema_base.yaml
@@ -60,13 +60,13 @@ enums:
   JGISampleFormatEnum:
     permissible_values:
       10 mM Tris-HCl:
-      DNAStable:
       Ethanol:
+      Gentegra-DNA:
+      Gentegra-RNA:
       Low EDTA TE:
       MDA reaction buffer:
       PBS:
       Pellet:
-      RNAStable:
       TE:
       Water:
   EnvPackageEnum:


### PR DESCRIPTION
This is follow-on work to #347.

In testing, I realized that some existing submission data was using the `Gentegra-DNA` permissible value. Through a quirk of the import-from-`nmdc-schema` process, that permissible value became part of the final `submission-schema` build, even though it wasn't listed in `nmdc_submission_schema_base.yaml`. The changes in #347 make it so that we no longer import the permissible value from `nmdc-schema` (which is good because the entire enum in `nmdc-schema` will go away eventually). But now we need to ensure that the enum in `submission-schema` is actually correct. 

These changes get us back in sync with what JGI actually allows by removing `DNAStable`/`RNAStable` and adding `Gentegra-DNA`/Gentegra-RNA`.