### PR TITLE
Use slot name instead of title in `slot_group`

### DIFF
--- a/src/nmdc_submission_schema/schema/nmdc_submission_schema_base.yaml
+++ b/src/nmdc_submission_schema/schema/nmdc_submission_schema_base.yaml
@@ -448,7 +448,7 @@ slots:
     examples:
       - value: '187654'
     rank: 3
-    slot_group: JGI-Metagenomics
+    slot_group: jgi_metagenomics_section
     range: string
     required: true
     aliases:


### PR DESCRIPTION
Fixes #336 

This was the last remaining place where a slot title was being referenced by a `slot_group`. The change is to use the slot's name instead.