### PR TITLE
Ensure that slot gets removed if slot ancestors will also be removed

### DIFF
--- a/tests/schematools/test_utils.py
+++ b/tests/schematools/test_utils.py
@@ -175,6 +175,31 @@ classes:
     assert "e" in schema.all_slots()
 
 
+def test_remove_class_removes_slots_via_slot_inheritance():
+    """Test that remove_class with remove_dangling_classes=True removes slots that become dangling
+    due to slot inheritance."""
+    schema = SchemaView("""
+id: http://example.org/test
+name: TestSchema
+slots:
+  a:
+  b:
+  c:
+    is_a: a
+classes:
+  TestClass:
+    slots:
+      - a
+      - b
+      - c
+""")
+    remove_class(schema, "TestClass", remove_dangling_classes=True)
+    assert "TestClass" not in schema.all_classes()
+    assert "a" not in schema.all_slots()
+    assert "b" not in schema.all_slots()
+    assert "c" not in schema.all_slots()
+
+
 def test_merge_prefixes():
     """Test that merge_prefixes correctly merges prefixes from source to target schema."""
     source_schema = SchemaView("""


### PR DESCRIPTION
Fixes #28 

The changes in #357 ensured that when classes are removed from the schema, their slots are also removed if they are not used by other classes or slots. There was, however, one slot listed in #28 that remained: `has_numeric_value`. That's because it was still referenced via slot inheritance (`has_maximum_numeric_value`) by another slot that was _also_ going to be removed. These changes update the `remove_class` logic to also attempt to remove slot ancestors if they would also become unused. 