### PR TITLE
Add `other_treatment` and `experimental_factor_other` to all MIxS env interfaces

### DIFF
--- a/config/nmdc_schema_import.yaml
+++ b/config/nmdc_schema_import.yaml
@@ -1763,7 +1763,18 @@ slots:
     source: Biosample
     destinations:
       - SoilMixsInspiredMixin
+      - AirInterface
+      - BiofilmInterface
+      - BuiltEnvInterface
+      - HcrCoresInterface
+      - HcrFluidsSwabsInterface
+      - HostAssociatedInterface
+      - MiscEnvsInterface
+      - PlantAssociatedInterface
+      - SedimentInterface
       - SoilInterface
+      - WastewaterSludgeInterface
+      - WaterInterface
     modifications:
       - replace:
           rank: 7
@@ -3264,7 +3275,18 @@ slots:
     source: Biosample
     destinations:
       - SoilMixsInspiredMixin
+      - AirInterface
+      - BiofilmInterface
+      - BuiltEnvInterface
+      - HcrCoresInterface
+      - HcrFluidsSwabsInterface
+      - HostAssociatedInterface
+      - MiscEnvsInterface
+      - PlantAssociatedInterface
+      - SedimentInterface
       - SoilInterface
+      - WastewaterSludgeInterface
+      - WaterInterface
     modifications:
       - replace:
           rank: 15

--- a/src/nmdc_submission_schema/schema/nmdc_submission_schema_base.yaml
+++ b/src/nmdc_submission_schema/schema/nmdc_submission_schema_base.yaml
@@ -1024,8 +1024,8 @@ classes:
       - interleaved_url
       - interleaved_md5_checksum
   DhMultiviewCommonColumnsMixin:
-    description: Mixin with DhMutliviewCommon Columns
-    title: Dh Mutliview Common Columns
+    description: Mixin with DhMultiviewCommon Columns
+    title: Dh Multiview Common Columns
     mixin: true
   SampIdNewTermsMixin:
     description: Mixin with SampIdNew Terms


### PR DESCRIPTION
Closes #411 

This PR adds all MIxS environmental interfaces as destinations for the slots `other_treatment` and `experimental_factor_other` upon import.