### PR TITLE
Upgrade `nmdc-schema` to `v11.20.0-rc.1`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dev = [
     "matplotlib>=3.9.2,<4",
     "mkdocs-material>=9.1.2,<10",
     "mkdocs-mermaid2-plugin>=1.1.0,<2",
-    "nmdc-schema==11.19.1",
+    "nmdc-schema==11.20.0rc1",
     "oaklib>=0.6.1,<0.7", # was using 0.5.6 up to 2024-12-10
     "pydantic>=2.11.7,<3",
     "pytest>=9.0.0,<10",

--- a/uv.lock
+++ b/uv.lock
@@ -1343,11 +1343,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -2784,12 +2784,13 @@ wheels = [
 
 [[package]]
 name = "nmdc-schema"
-version = "11.19.1"
+version = "11.20.0rc1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "click-log" },
     { name = "deprecated" },
+    { name = "idna" },
     { name = "jsonasobj2" },
     { name = "jsonschema" },
     { name = "linkml" },
@@ -2800,10 +2801,11 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rdflib" },
     { name = "requests" },
+    { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fa/0d/0d9c7f85fd85fa9a7a9440f7943512af7e7b823511bc5b1c6cee9ef55d83/nmdc_schema-11.19.1.tar.gz", hash = "sha256:e258dfc31506dd325cd674a11284e9a9529c82d5a1b842184525f40a83927e30", size = 725052, upload-time = "2026-05-08T16:42:29.872Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a0/e9/4eb09bf6aa8e2c0b2c69815e21f45bcd492b94061864802ade12414f2596/nmdc_schema-11.20.0rc1.tar.gz", hash = "sha256:7524de0c68eac332fcbd1064f5a53d7be38a3be52af245e7143eb845d460f33d", size = 764866, upload-time = "2026-06-03T14:54:08.932Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/9f/62e5b713a242bd4a1efca0f70f1efadd334656ee28251f4ea3c9f2aa67b6/nmdc_schema-11.19.1-py3-none-any.whl", hash = "sha256:e2df19d58c45714641e2ec93b55bb6e90c9da470f8e7fc49ba437db859019a67", size = 798170, upload-time = "2026-05-08T16:42:27.839Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/0b/bd3617da0c6ce81c5349c9140f087745e86b0310963cbea326ac9c3d84a0/nmdc_schema-11.20.0rc1-py3-none-any.whl", hash = "sha256:7e843c39606cd5f803ebe53b72a24d999cf4df0b7eb78c8c091224f30a91951b", size = 838561, upload-time = "2026-06-03T14:54:07.224Z" },
 ]
 
 [[package]]
@@ -2857,7 +2859,7 @@ dev = [
     { name = "matplotlib", specifier = ">=3.9.2,<4" },
     { name = "mkdocs-material", specifier = ">=9.1.2,<10" },
     { name = "mkdocs-mermaid2-plugin", specifier = ">=1.1.0,<2" },
-    { name = "nmdc-schema", specifier = "==11.19.1" },
+    { name = "nmdc-schema", specifier = "==11.20.0rc1" },
     { name = "oaklib", specifier = ">=0.6.1,<0.7" },
     { name = "pydantic", specifier = ">=2.11.7,<3" },
     { name = "pytest", specifier = ">=9.0.0,<10" },
@@ -3674,15 +3676,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.2"
+version = "10.21.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
 ]
 
 [[package]]
@@ -4953,11 +4955,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
On this branch, I am upgrading the version of `nmdc-schema` dependency in this repo to the release candidate `v11.20.0-rc.1`.

See pre-release on PyPI: https://pypi.org/project/nmdc-schema/11.20.0rc1/