### PR TITLE
Remove analysis_type workaround; use isolate genome sequencing enum value

### DIFF
--- a/src/data/valid/SampleData-isolate_data-exhaustive.yaml
+++ b/src/data/valid/SampleData-isolate_data-exhaustive.yaml
@@ -3,24 +3,18 @@
 ## Source: GOLD analysis project Ga0028539, its_analysis_project_id 1377532
 ## Retrieved from gold-db-2 postgresql.gold.analysis_project via JGI Dremio lakehouse.
 ##
-## NOTE: analysis_type is not included; AnalysisTypeEnum has no isolate-WGS value yet.
-## A permissible value should be added to AnalysisTypeEnum in nmdc-schema. Until then,
-## analysis_type is overridden to required: false in IsolateInterface and JgiIsolateInterface.
-##
 ## NOTE: IsolateInterface nmdc-schema slots (organism_genus, organism_species, strain_name,
 ## isolate_name, classified_as, host_taxid, collection_date) are absent here — they are
 ## wired in via config/nmdc_schema_import.yaml once nmdc-schema PR #2977 and #2975 merge.
 isolate_data:
   - samp_name: Dictyoglomus_turgidum_DSM6724_isolate001
-    # analysis_type placeholder — no isolate WGS value in AnalysisTypeEnum yet (nmdc-schema#3017)
     analysis_type:
-      - metagenomics
+      - isolate genome sequencing
     source_mat_id: igsn:000
 jgi_isolate_data:
   - samp_name: Dictyoglomus_turgidum_DSM6724_isolate001
-    # analysis_type placeholder — no isolate WGS value in AnalysisTypeEnum yet (nmdc-schema#3017)
     analysis_type:
-      - metagenomics
+      - isolate genome sequencing
     source_mat_id: igsn:000
     ## --- JGI project logistics (real values from GOLD Ga0028539 / ITS project 1377532) ---
     replicate_group: Dturgidum_rep1

--- a/src/nmdc_submission_schema/schema/nmdc_submission_schema_base.yaml
+++ b/src/nmdc_submission_schema/schema/nmdc_submission_schema_base.yaml
@@ -1226,7 +1226,6 @@ classes:
     is_a: DhInterface
     mixins:
       - DhMultiviewCommonColumnsMixin
-    slot_usage:
     # nmdc-schema slots (organism_genus, organism_species, strain_name, isolate_name,
     # source_mat_id, classified_as, host_taxid, collection_date) are routed here
     # via config/nmdc_schema_import.yaml once PR #2977 is released.

--- a/src/nmdc_submission_schema/schema/nmdc_submission_schema_base.yaml
+++ b/src/nmdc_submission_schema/schema/nmdc_submission_schema_base.yaml
@@ -1227,14 +1227,9 @@ classes:
     mixins:
       - DhMultiviewCommonColumnsMixin
     slot_usage:
-      # analysis_type has no valid enum value for isolate WGS; suppress the inherited
-      # required constraint until a proper value is added to AnalysisTypeEnum in nmdc-schema
-      analysis_type:
-        required: false
     # nmdc-schema slots (organism_genus, organism_species, strain_name, isolate_name,
     # source_mat_id, classified_as, host_taxid, collection_date) are routed here
     # via config/nmdc_schema_import.yaml once PR #2977 is released.
-    # TODO: add isolate WGS permissible value to AnalysisTypeEnum in nmdc-schema
     # TODO: resolve open debate on estimated_size, gc_content, biosafety_mat_cat
     # (currently JGI-only per Montana's spreadsheet; see submission-schema#418)
 
@@ -1282,10 +1277,6 @@ classes:
       - isolate_fungal_16s_screening
       - isolate_its_match_unite
     slot_usage:
-      # analysis_type has no valid enum value for isolate WGS; suppress the inherited
-      # required constraint until a proper value is added to AnalysisTypeEnum in nmdc-schema
-      analysis_type:
-        required: false
       replicate_group:
         slot_group: jgi_isolate_section
       jgi_samp_id:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -235,13 +235,13 @@ TEMPLATE_INSTANCES = {
         "lat_lon": "12.34 -56.78",
         "samp_name": "000001",
     },
-    # analysis_type is required: false in IsolateInterface and JgiIsolateInterface because
-    # AnalysisTypeEnum has no isolate WGS value yet; see submission-schema#418
     "IsolateInterface": {
         "samp_name": "000001",
+        "analysis_type": ["isolate genome sequencing"],
     },
     "JgiIsolateInterface": {
         "samp_name": "000001",
+        "analysis_type": ["isolate genome sequencing"],
         "nuc_acid_concentration": 1.0,
         "cont_type": "plate",
         "cont_well": "C5",


### PR DESCRIPTION
`AnalysisTypeEnum` gained `isolate genome sequencing` and `isolate transcriptome sequencing` in nmdc-schema v11.19.2-rc.1 (commit bdcc3f76f, Alicia Clum). The `required: false` overrides on `IsolateInterface` and `JgiIsolateInterface` were a temporary workaround until those values existed.

This PR removes both overrides, removes the stale TODO comments, and updates the exhaustive example to use `isolate genome sequencing`.

PR https://github.com/microbiomedata/submission-schema/pull/434 (nmdc-schema v11.20.0-rc.1 upgrade) has merged; this PR depends on PR https://github.com/microbiomedata/submission-schema/pull/423 merging first.

Closes https://github.com/microbiomedata/nmdc-schema/issues/3017